### PR TITLE
feat - add generate key in nuxt.config.js: create posts/post_name rou…

### DIFF
--- a/nuxt/assets/images/banners/posts/README.md
+++ b/nuxt/assets/images/banners/posts/README.md
@@ -16,5 +16,5 @@ This folder shall include banner images for a post.
 
 * pages/posts/_name/index.vue
 * components/posts/AppPostBanner.vue
-
+* nuxt.config.js (generate)
 

--- a/nuxt/assets/images/map-previews/README.md
+++ b/nuxt/assets/images/map-previews/README.md
@@ -1,0 +1,15 @@
+#Content
+
+This folder shall include images preview of a graph.
+
+#Image Files:  Naming Rules
+
+* **The image shall be a .png file**
+
+#Reference code:
+
+* components/UI/MapPreview.vue
+
+
+
+

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -117,6 +117,10 @@ export default {
       const routes = [];
       for (const filename of posts) {
         routes.push("/posts/" + filename);
+        routes.push("/posts/" + filename + "/sources");
+        routes.push("/posts/" + filename + "/graphs");
+        routes.push("/posts/" + filename + "/stakeholders");
+        routes.push("/posts/" + filename + "/definitions");
       }
       return routes;
     }

--- a/nuxt/nuxt.config.js
+++ b/nuxt/nuxt.config.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+
 export default {
   mode: "spa",
   /*
@@ -102,6 +104,24 @@ export default {
     algoliaKey: process.env.ALGOLIA_KEY
   },
   "nuxt-compress": { gzip: { cache: true }, brotli: { threshold: 10240 } },
+
+  generate: {
+    routes: function() {
+      const posts = fs
+        .readdirSync("assets/images/banners/posts/")
+        .filter(file => file.indexOf(".") !== 0 && file.slice(-4) === ".png")
+        .map(pngfilename => {
+          return pngfilename.slice(0, -4);
+          // "postname.png" --> "postname"
+        });
+      const routes = [];
+      for (const filename of posts) {
+        routes.push("/posts/" + filename);
+      }
+      return routes;
+    }
+  },
+
   /*
    ** Build configuration
    */


### PR DESCRIPTION
add generate key in nuxt.config.js: create posts/post_name routes when "yarn --cwd ./nuxt run generate" is run based on the file names in assets/images/banners/posts. Update README there as well